### PR TITLE
Online status

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,10 @@ var (
 	RedisDebug = readBool("REDIS_DEBUG", false)
 
 	// RedisConnectionsDebug toggles logging when redis connections are obtained and freed.
-	RedisConnectionsDebug = readBool("REDIS_CONNECTIONS", true)
+	RedisConnectionsDebug = readBool("REDIS_CONNECTIONS", false)
+
+	// ShutdownHandlersDbug toggles logging of shutdown handlers being registered and used.
+	ShutdownHandlersDebug = readBool("SHUTDOWN_HANDLERS_DEBUG", false)
 
 	// StreamDebug toggles extra logging for the SSE stream tasks
 	StreamDebug = readBool("STREAM_DEBUG", false)

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,9 @@ var (
 	// RedisDebug toggles logging every Redis command.
 	RedisDebug = readBool("REDIS_DEBUG", false)
 
+	// RedisConnectionsDebug toggles logging when redis connections are obtained and freed.
+	RedisConnectionsDebug = readBool("REDIS_CONNECTIONS", true)
+
 	// SlowResponsesDebug adds 5s to each response handler for debugging purposes.
 	// This value is ignored on production.
 	SlowResponsesDebug = readBool("SLOW_RESPONSES_DEBUG", false)

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ var (
 	// RedisConnectionsDebug toggles logging when redis connections are obtained and freed.
 	RedisConnectionsDebug = readBool("REDIS_CONNECTIONS", true)
 
+	// StreamDebug toggles extra logging for the SSE stream tasks
+	StreamDebug = readBool("STREAM_DEBUG", false)
+
 	// SlowResponsesDebug adds 5s to each response handler for debugging purposes.
 	// This value is ignored on production.
 	SlowResponsesDebug = readBool("SLOW_RESPONSES_DEBUG", false)

--- a/event/event.go
+++ b/event/event.go
@@ -1,13 +1,10 @@
 package event
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/gomodule/redigo/redis"
-	redisUtil "sr/redis"
 	"strconv"
-	"strings"
 )
 
 // ValidID returns whether the non-empty-string id is valid.
@@ -92,57 +89,4 @@ func BulkUpdate(gameID string, events []Event, conn redis.Conn) error {
 		)
 	}
 	return nil
-}
-
-// SubscribeToGame starts a goroutine that reads from the given game's history
-// and update channels.
-// Each update is sent over the returned string channel, with a prefix "event:"
-// for events and "update:" for updates.
-// The given context is used for its cancellation function. Errors (such as being
-// canceled) are sent over the error channel.
-func SubscribeToGame(ctx context.Context, gameID string) (<-chan string, <-chan error) {
-	events := make(chan string)
-	errChan := make(chan error, 1)
-
-	conn := redisUtil.Connect()
-
-	sub := redis.PubSubConn{Conn: conn}
-	if err := sub.Subscribe("history:"+gameID, "update:"+gameID); err != nil {
-		errChan <- fmt.Errorf("unable to subscribe to update channels: %w", err)
-		redisUtil.Close(conn)
-		close(events)
-		close(errChan)
-		return events, errChan
-	}
-
-	go func() {
-		defer func() {
-			sub.Unsubscribe()
-			redisUtil.Close(conn)
-			close(events)
-			close(errChan)
-		}()
-		for {
-			select {
-			case <-ctx.Done():
-				errChan <- fmt.Errorf("received done from context: %w", ctx.Err())
-				return
-			default:
-			}
-			switch msg := sub.Receive().(type) {
-			case error:
-				errChan <- fmt.Errorf("error from redis Receive(): %w", msg)
-				return
-			case redis.Message:
-				message := string(msg.Data)
-				if strings.HasPrefix(msg.Channel, "history") {
-					message = "event:" + message
-				} else {
-					message = "update:" + message
-				}
-				events <- message
-			}
-		}
-	}()
-	return events, errChan
 }

--- a/game/game.go
+++ b/game/game.go
@@ -29,7 +29,7 @@ func GetPlayersIn(gameID string, conn redis.Conn) ([]player.Player, error) {
 		}
 		playerIDs, err := redis.Strings(conn.Do("SMEMBERS", "players:"+gameID))
 		if err != nil {
-			return nil, nil, fmt.Errorf("redis error retrieving player ID list: %w")
+			return nil, nil, fmt.Errorf("redis error retrieving player ID list: %w", err)
 		}
 		if playerIDs == nil || len(playerIDs) == 0 {
 			if _, err := conn.Do("UNWATCH"); err != nil {
@@ -72,12 +72,12 @@ func GetPlayersIn(gameID string, conn redis.Conn) ([]player.Player, error) {
 		} else if errors.Is(err, ErrNotFound) {
 			return nil, err
 		} else if err != nil {
-			return nil, fmt.Errorf("After %s attempt(s): %w", i+1, err)
+			return nil, fmt.Errorf("after %v attempt(s): %w", i+1, err)
 		}
 		break
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Error after max attempts: %w", err)
+		return nil, fmt.Errorf("after max attempts: %w", err)
 	}
 
 	players := make([]player.Player, len(playerMaps))

--- a/game/playerManager.go
+++ b/game/playerManager.go
@@ -102,16 +102,10 @@ func UpdatePlayer(gameID string, playerID id.UID, externalUpdate update.Player, 
 			return fmt.Errorf("redis error sending event publish: %w", err)
 		}
 	}
-	// EXEC: [#new=0, #players]
-	results, err := redis.Ints(conn.Do("EXEC"))
+	// EXEC: [0] for just internal, [#players] for just external, [#new=0, #players] for both
+	_, err := redis.Ints(conn.Do("EXEC"))
 	if err != nil {
 		return fmt.Errorf("redis error sending EXEC: %w", err)
-	}
-	if len(results) != 2 {
-		return fmt.Errorf("redis error updating player, expected 2 results got %v", results)
-	}
-	if results[0] != 0 {
-		return fmt.Errorf("redis error updating player, expected [0, *] got %v", results)
 	}
 	return nil
 }

--- a/game/playerManager.go
+++ b/game/playerManager.go
@@ -78,9 +78,9 @@ func UpdatePlayerConnections(gameID string, playerID id.UID, mod int, conn redis
 
 // UpdatePlayer updates a player in the database.
 // It does not allow for username updates. It only publishes the update to the given game.
-func UpdatePlayer(gameID string, playerID id.UID, update update.Player, conn redis.Conn) error {
-	playerSet, playerData := update.MakeRedisCommand()
-	updateBytes, err := json.Marshal(update)
+func UpdatePlayer(gameID string, playerID id.UID, externalUpdate update.Player, internalUpdate update.Player, conn redis.Conn) error {
+	playerSet, playerData := internalUpdate.MakeRedisCommand()
+	updateBytes, err := json.Marshal(externalUpdate)
 	if err != nil {
 		return fmt.Errorf("unable to marshal update to JSON :%w", err)
 	}

--- a/game/playerManager.go
+++ b/game/playerManager.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gomodule/redigo/redis"
+	"log"
 	"sr/id"
 	"sr/player"
 	"sr/update"
@@ -39,6 +40,40 @@ func AddPlayer(gameID string, player *player.Player, conn redis.Conn) error {
 		)
 	}
 	return nil
+}
+
+func UpdatePlayerConnections(gameID string, playerID id.UID, mod int, conn redis.Conn) (int, error) {
+	newConns, err := player.ModifyConnections(playerID, mod, conn)
+	if err != nil {
+		return 0, fmt.Errorf("redis error updating connections for %v: %w", playerID, err)
+	}
+	// Race conditions
+	// - We assume that for each incr we will eventually send a decr.
+	// - We assume we have not sent a decr without having sent an incr.
+	// - Redis incr and decr are atomic, so we assume the sends will go through.
+	// - We DO NOT assume the sends will go through in order.
+	// - We assume the connection MAY drop below 0 if decrs are processed before incrs.
+	// We assume this may only happen in a sceario where an incrs will come through later
+	// and match the decrs; i.e. if we have observed connections < 0 we expect to settle on
+	// connections = 0. Because of this, we do not send updates for connections < 0.
+	var ud update.Player
+	// Decreasd to 0; going offline
+	if newConns == 0 && mod == player.DecreaseConnections {
+		ud = update.ForPlayerOnline(playerID, false)
+	} else if newConns == 1 && mod == player.IncreaseConnections {
+		ud = update.ForPlayerOnline(playerID, true)
+	} else {
+		log.Printf("Mod = %v, connections = %v, not sending an update", mod, newConns)
+		return newConns, nil
+	}
+	updateBytes, err := json.Marshal(ud)
+	if err != nil {
+		return newConns, fmt.Errorf("unable to marshal %#v to JSON: %w", ud, err)
+	}
+	if _, err = conn.Do("PUBLISH", "update:"+gameID, updateBytes); err != nil {
+		return newConns, fmt.Errorf("redis error publishing %#v: %w", ud, err)
+	}
+	return newConns, nil
 }
 
 // UpdatePlayer updates a player in the database.

--- a/game/subscribe.go
+++ b/game/subscribe.go
@@ -1,0 +1,92 @@
+package game
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	redisUtil "sr/redis"
+)
+
+type MessageType int
+
+const MessageTypeEvent MessageType = MessageType(1)
+const MessageTypeUpdate MessageType = MessageType(2)
+
+type Message struct {
+	Type MessageType
+	Body string
+}
+
+func subscribeTask(cleanup func(), messages chan Message, errs chan error, sub redis.PubSubConn, ctx context.Context) {
+	defer cleanup()
+	for {
+		// Check if we have received done yet
+		select {
+		case <-ctx.Done():
+			errs <- fmt.Errorf("received done from context: err = %w", ctx.Err())
+			return
+		default:
+			log.Print("No Done() this ping")
+		}
+		const pollInterval = time.Duration(4) * time.Second
+		// Receive an event or update from the game
+		switch msg := sub.ReceiveWithTimeout(pollInterval).(type) {
+		case error:
+			log.Printf("Received error %#v", msg)
+			var netError net.Error
+			if errors.As(msg, &netError) {
+				if netError.Timeout() {
+					log.Print("Subscription helper loop")
+					continue
+				}
+			}
+			errs <- fmt.Errorf("from redis Receive(): %w", msg)
+			return
+		case redis.Message:
+			var message Message
+			messageText := string(msg.Data)
+			if strings.HasPrefix(msg.Channel, "history") {
+				message = Message{Type: MessageTypeEvent, Body: messageText}
+			} else {
+				message = Message{Type: MessageTypeUpdate, Body: messageText}
+			}
+			messages <- message
+		case redis.Subscription:
+			// okay; ignore
+			log.Printf("Helper: %#v", msg)
+		default:
+			errs <- fmt.Errorf("unexpected value for Receive(): %#v", msg)
+		}
+	}
+}
+
+func Subscribe(gameID string, messages chan Message, errors chan error, ctx context.Context) error {
+	conn, err := redisUtil.ConnectWithContext(ctx)
+	if err != nil {
+		close(errors)
+		close(messages)
+		return fmt.Errorf("dialing redis with context: %w", err)
+	}
+	sub := redis.PubSubConn{Conn: conn}
+
+	cleanup := func() {
+		log.Print("Cleaning up subscribe task")
+		sub.Unsubscribe()
+		redisUtil.Close(conn)
+		close(errors)
+		close(messages)
+	}
+
+	if err := sub.Subscribe("history:"+gameID, "update:"+gameID); err != nil {
+		cleanup()
+		return fmt.Errorf("subscribing to events and history: %w", err)
+	}
+	go subscribeTask(cleanup, messages, errors, sub, ctx)
+	return nil
+}

--- a/player/player.go
+++ b/player/player.go
@@ -18,22 +18,9 @@ var ErrNotFound = errors.New("player not found")
 // OnlineMode is a toggle for show as online/show as offline
 type OnlineMode = int
 
-var OnlineModeAuto OnlineMode = 0    // Show as online if connected
+var OnlineModeAuto OnlineMode        // Show as online if connected
 var OnlineModeOnline OnlineMode = 1  // Always show as onlilne
 var OnlineModeOffline OnlineMode = 2 // Always show as offline
-
-func OnlineModeString(mode OnlineMode) string {
-	switch mode {
-	case OnlineModeAuto:
-		return "auto"
-	case OnlineModeOnline:
-		return "alwaysOnline"
-	case OnlineModeOffline:
-		return "alwaysOffline"
-	default:
-		return "auto"
-	}
-}
 
 // Player is a user of Shadowroller.
 //
@@ -72,7 +59,7 @@ func (p *Player) MarshalJSON() ([]byte, error) {
 	fields["hue"] = p.Hue
 	fields["username"] = p.Username
 	fields["online"] = p.IsOnline()
-	fields["onlineMode"] = OnlineModeString(p.OnlineMode)
+	fields["onlineMode"] = p.OnlineMode
 	return json.Marshal(fields)
 }
 
@@ -86,6 +73,7 @@ func (p *Player) Info() Info {
 	}
 }
 
+// IsOnline indicates if a player is actively connected, or has chosen to be seen as such.
 func (p *Player) IsOnline() bool {
 	switch p.OnlineMode {
 	case OnlineModeAuto:

--- a/player/player.go
+++ b/player/player.go
@@ -15,11 +15,25 @@ import (
 // ErrNotFound means a player was not found.
 var ErrNotFound = errors.New("player not found")
 
+// OnlineMode is a toggle for show as online/show as offline
 type OnlineMode = int
 
-var OnlineModeAuto OnlineMode = 0
-var OnlineModeOnline OnlineMode = 1
-var OnlineModeOffline OnlineMode = 2
+var OnlineModeAuto OnlineMode = 0    // Show as online if connected
+var OnlineModeOnline OnlineMode = 1  // Always show as onlilne
+var OnlineModeOffline OnlineMode = 2 // Always show as offline
+
+func OnlineModeString(mode OnlineMode) string {
+	switch mode {
+	case OnlineModeAuto:
+		return "auto"
+	case OnlineModeOnline:
+		return "alwaysOnline"
+	case OnlineModeOffline:
+		return "alwaysOffline"
+	default:
+		return "auto"
+	}
+}
 
 // Player is a user of Shadowroller.
 //
@@ -57,7 +71,8 @@ func (p *Player) MarshalJSON() ([]byte, error) {
 	fields["name"] = p.Name
 	fields["hue"] = p.Hue
 	fields["username"] = p.Username
-	fields["online"] = p.Connections > 0
+	fields["online"] = p.IsOnline()
+	fields["onlineMode"] = OnlineModeString(p.OnlineMode)
 	return json.Marshal(fields)
 }
 

--- a/player/player.go
+++ b/player/player.go
@@ -282,8 +282,8 @@ func Create(player *Player, conn redis.Conn) error {
 	return nil
 }
 
-const IncreaseConnections = 1
-const DecreaseConnections = 2
+const IncreaseConnections = +1
+const DecreaseConnections = -1
 
 func ModifyConnections(playerID id.UID, amount int, conn redis.Conn) (int, error) {
 	return redis.Int(conn.Do(

--- a/player/player.go
+++ b/player/player.go
@@ -18,9 +18,14 @@ var ErrNotFound = errors.New("player not found")
 // OnlineMode is a toggle for show as online/show as offline
 type OnlineMode = int
 
-var OnlineModeAuto OnlineMode        // Show as online if connected
-var OnlineModeOnline OnlineMode = 1  // Always show as onlilne
-var OnlineModeOffline OnlineMode = 2 // Always show as offline
+// OnlineModeAuto indicates a player will be shown as online when connected to a game
+var OnlineModeAuto OnlineMode
+
+// OnlineModeOnline indicates a player will always be shown as online
+var OnlineModeOnline OnlineMode = 1
+
+// OnlineModeOffline indicates a player will always be shown as offline
+var OnlineModeOffline OnlineMode = 2
 
 // Player is a user of Shadowroller.
 //
@@ -308,9 +313,13 @@ func Create(player *Player, conn redis.Conn) error {
 	return nil
 }
 
+// IncreaseConnections is used when a new connection is established
 const IncreaseConnections = +1
+
+// DecreaseConnections is used when a connection is closed
 const DecreaseConnections = -1
 
+// ModifyConnections modifies the Connections attribute of a player; used by the subscription handler
 func ModifyConnections(playerID id.UID, amount int, conn redis.Conn) (int, error) {
 	return redis.Int(conn.Do(
 		"HINCRBY", "player:"+playerID, "connections", amount,

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -19,6 +19,9 @@ var pool = &redis.Pool{
 		if config.RedisDebug && err == nil {
 			return redis.NewLoggingConn(conn, logger, "redis"), nil
 		}
+		if config.RedisConnectionsDebug {
+			log.Printf("Dialing connection from pool: %p", conn)
+		}
 		return conn, err
 	},
 }
@@ -30,9 +33,16 @@ func Connect() redis.Conn {
 
 // Close closes a redis connection and logs errors if they occur
 func Close(conn redis.Conn) {
+	if config.RedisConnectionsDebug {
+		log.Printf("Called redisUtil.Close with %p", conn)
+	}
+	if conn == nil {
+		log.Printf("Attempted to close nil connection")
+		return
+	}
 	err := conn.Close()
 	if err != nil {
-		log.Printf("Error closing redis connection: %v", err)
+		log.Printf("Error closing redis connection %p: %v", conn, err)
 	}
 }
 

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -49,7 +49,7 @@ func ConnectWithContext(ctx context.Context) (redis.Conn, error) {
 // Close closes a redis connection and logs errors if they occur
 func Close(conn redis.Conn) {
 	if config.RedisConnectionsDebug {
-		log.Printf("Called redisUtil.Close with %p", conn)
+		log.Printf("Called redisUtil.Close(): %p", conn)
 	}
 	if conn == nil {
 		log.Printf("Attempted to close nil connection")

--- a/routes/auth.go
+++ b/routes/auth.go
@@ -5,7 +5,6 @@ import (
 	"sr/auth"
 	"sr/game"
 	"sr/player"
-	redisUtil "sr/redis"
 	"sr/session"
 )
 
@@ -39,9 +38,7 @@ func handleLogin(response Response, request *Request) {
 		login.Username, login.GameID, status,
 	)
 
-	conn := redisUtil.Connect()
-	defer closeRedis(request, conn)
-
+	conn := contextRedisConn(request.Context())
 	gameInfo, plr, err := auth.LogPlayerIn(login.GameID, login.Username, conn)
 	if err != nil {
 		logf(request, "Login response: %v", err)
@@ -91,9 +88,7 @@ func handleReauth(response Response, request *Request) {
 		"Relogin request for session %v", requestSession,
 	)
 
-	conn := redisUtil.Connect()
-	defer closeRedis(request, conn)
-
+	conn := contextRedisConn(request.Context())
 	sess, err := session.GetByID(requestSession, conn)
 	httpUnauthorizedIf(response, request, err)
 	logf(request, "Found session %s", sess.String())

--- a/routes/game.go
+++ b/routes/game.go
@@ -349,7 +349,7 @@ func collectRolls(in interface{}) ([]int, error) {
 
 var removeDecimal = regexp.MustCompile(`\.\d+`)
 
-var _ = gameRouter.HandleFunc("/subscription", handleSubscription).Methods("GET")
+//var _ = gameRouter.HandleFunc("/subscription", handleSubscription).Methods("GET")
 
 // GET /subscription?session= Last-Event-ID: -> SSE :ping, event
 func handleSubscription(response Response, request *Request) {

--- a/routes/game.go
+++ b/routes/game.go
@@ -26,7 +26,6 @@ func handleInfo(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
 	httpUnauthorizedIf(response, request, err)
-	defer closeRedis(request, conn)
 
 	info, err := game.GetInfo(sess.GameID, conn)
 	httpInternalErrorIf(response, request, err)
@@ -54,7 +53,6 @@ func handleUpdateEvent(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
 	httpUnauthorizedIf(response, request, err)
-	defer closeRedis(request, conn)
 
 	var updateRequest updateEventRequest
 	err = readBodyJSON(request, &updateRequest)
@@ -127,7 +125,6 @@ type deleteEventRequest struct {
 func handleDeleteEvent(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
 
 	var delete deleteEventRequest
@@ -173,7 +170,6 @@ func handleRoll(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
 	httpUnauthorizedIf(response, request, err)
-	defer closeRedis(request, conn)
 
 	var roll rollRequest
 	err = readBodyJSON(request, &roll)
@@ -232,7 +228,6 @@ var _ = gameRouter.HandleFunc("/roll-initiative", handleRollInitiative).Methods(
 func handleRollInitiative(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
 
 	player, err := sess.GetPlayer(conn)
@@ -286,7 +281,6 @@ var _ = gameRouter.HandleFunc("/reroll", handleReroll).Methods("POST")
 func handleReroll(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
 
 	var reroll rerollRequest
@@ -362,7 +356,6 @@ func handleSubscription(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestParamSession(request)
 	httpUnauthorizedIf(response, request, err)
-	defer closeRedis(request, conn)
 	logf(request, "Player %v to connect to %v", sess.PlayerID, sess.GameID)
 
 	// Upgrade to SSE stream
@@ -513,7 +506,6 @@ var _ = gameRouter.HandleFunc("/events", handleEvents).Methods("GET")
 func handleEvents(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
 
 	newest := request.FormValue("newest")

--- a/routes/game.go
+++ b/routes/game.go
@@ -25,8 +25,8 @@ var _ = gameRouter.HandleFunc("/info", handleInfo).Methods("GET")
 func handleInfo(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
+	defer closeRedis(request, conn)
 
 	info, err := game.GetInfo(sess.GameID, conn)
 	httpInternalErrorIf(response, request, err)
@@ -53,8 +53,8 @@ type updateEventRequest struct {
 func handleUpdateEvent(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
+	defer closeRedis(request, conn)
 
 	var updateRequest updateEventRequest
 	err = readBodyJSON(request, &updateRequest)
@@ -172,8 +172,8 @@ var _ = gameRouter.HandleFunc("/roll", handleRoll).Methods("POST")
 func handleRoll(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
+	defer closeRedis(request, conn)
 
 	var roll rollRequest
 	err = readBodyJSON(request, &roll)

--- a/routes/gameSubscription.go
+++ b/routes/gameSubscription.go
@@ -1,0 +1,145 @@
+package routes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sr/config"
+	"sr/event"
+	"sr/game"
+	"sr/id"
+	"sr/player"
+	"time"
+
+	"github.com/janberktold/sse"
+)
+
+func pingStream(stream *sse.Conn) error {
+	pingID := fmt.Sprintf("%v", id.NewEventID())
+	return stream.WriteEventWithID(pingID, "ping", []byte{})
+}
+
+func writeMessageToStream(message *game.Message, stream *sse.Conn) (string, error) {
+	var streamChannel string
+	var updateLog string
+	var messageID string
+	if message.Type == game.MessageTypeUpdate {
+		streamChannel = "update"
+		messageID = fmt.Sprintf("%v", id.NewEventID())
+		updateLog = fmt.Sprintf("update %v", message.Body)
+	} else { // event
+		streamChannel = "event"
+		messageID = event.ParseID(message.Body)
+		updateLog = fmt.Sprintf("event %v %v", event.ParseTy(message.Body), messageID)
+	}
+	return updateLog, stream.WriteEventWithID(messageID, streamChannel, []byte(message.Body))
+}
+
+var _ = gameRouter.HandleFunc("/subscription", handleSubscription2)
+
+func handleSubscription2(response Response, request *Request) {
+	logRequest(request)
+	sess, conn, err := requestParamSession(request)
+	httpUnauthorizedIf(response, request, err)
+	logf(request, "Player %v to connect to %v", sess.PlayerID, sess.GameID)
+
+	// Upgrade to SSE stream
+	stream, err := sseUpgrader.Upgrade(response, request)
+	httpBadRequestIf(response, request, err)
+	logf(request, "Upgraded to SSE")
+	defer func() {
+		if stream.IsOpen() {
+			stream.Close()
+		}
+	}()
+
+	// Subscribe to redis
+	ctx, cancel := context.WithCancel(request.Context())
+	messages := make(chan game.Message)
+	errors := make(chan error, 1)
+	err = game.Subscribe(sess.GameID, messages, errors, ctx)
+	httpInternalErrorIf(response, request, err)
+	logf(request, "Subscription task for %v established", sess.GameID)
+	defer cancel()
+
+	// Unexpire/delay expire of session
+	_, err = sess.Unexpire(conn)
+	httpInternalErrorIf(response, request, err)
+	logf(request, "Session timer for %v %v reset", sess.Type(), sess.ID)
+	defer func() {
+		if _, err := sess.Expire(conn); err != nil {
+			logf(request, "^^ Error resetting session: %v", err)
+		} else {
+			logf(request, "^^ Reset session timer for %v", sess.ID)
+		}
+	}()
+
+	// Update player online status
+	_, err = game.UpdatePlayerConnections(
+		sess.GameID, sess.PlayerID, player.IncreaseConnections, conn,
+	)
+	httpInternalErrorIf(response, request, err)
+	logf(request, "Incremented online status for %v", sess.PlayerID)
+	defer func() {
+		if _, err := game.UpdatePlayerConnections(
+			sess.GameID, sess.PlayerID, player.DecreaseConnections, conn,
+		); err != nil {
+			logf(request, "^^ Error decrementing player connections: %v", err)
+		} else {
+			logf(request, "^^ Decremented online status for %v", sess.PlayerID)
+		}
+	}()
+
+	// Log total time for response
+	defer func() {
+		dur := removeDecimal.ReplaceAllString(displayRequestDuration(ctx), "")
+		logf(request, ">> Subscription to %v for %v closed (%v)",
+			sess.GameID, sess.PlayerID, dur,
+		)
+	}()
+
+	// Allow long-running cleanup to happen on CTRL-C
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt)
+	defer signal.Stop(sigint)
+
+	// Begin receiving events
+	lastPing := time.Now() // We want to reping immediately
+	ssePingInterval := time.Duration(config.SSEPingSecs) * time.Second
+	const pollInterval = time.Duration(2) * time.Second
+	logf(request, "Begin receiving events...")
+	for {
+		now := time.Now()
+		// End connction if stream not open
+		if !stream.IsOpen() {
+			logf(request, "Connection closed by remote host")
+			return
+		}
+		// Ping stream every interval
+		if now.Sub(lastPing) >= ssePingInterval {
+			if err = pingStream(stream); err != nil {
+				logf(request, "Unable to write to stream: %v", err)
+				return
+			}
+			lastPing = now
+		}
+		select { // Receive message/error and wait out interval
+		case message := <-messages:
+			updateLog, err := writeMessageToStream(&message, stream)
+			if err != nil {
+				logf(request, "Error writing %v to stream", message.Body)
+				return
+			}
+			logf(request, "Sent %v to %v", updateLog, sess.PlayerID)
+		case err := <-errors:
+			logf(request, "<= Error from subscription task: %v", err)
+			return
+		case <-sigint:
+			logf(request, "SIGINT received; closing")
+			return
+		case <-time.After(pollInterval):
+			continue
+		}
+	}
+}

--- a/routes/gameSubscription.go
+++ b/routes/gameSubscription.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sr/config"
 	"sr/event"
 	"sr/game"
@@ -35,9 +36,11 @@ func writeMessageToStream(message *game.Message, stream *sse.Conn) (string, erro
 	return updateLog, stream.WriteEventWithID(messageID, streamChannel, []byte(message.Body))
 }
 
-var _ = gameRouter.HandleFunc("/subscription", handleSubscription2)
+var removeDecimal = regexp.MustCompile(`\.\d+`)
 
-func handleSubscription2(response Response, request *Request) {
+var _ = gameRouter.HandleFunc("/subscription", handleSubscription)
+
+func handleSubscription(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestParamSession(request)
 	httpUnauthorizedIf(response, request, err)

--- a/routes/gameSubscription.go
+++ b/routes/gameSubscription.go
@@ -106,7 +106,7 @@ func handleSubscription(response Response, request *Request) {
 	}()
 
 	// Begin receiving events
-	lastPing := time.Now() // We want to reping immediately
+	lastPing := time.Now()
 	ssePingInterval := time.Duration(config.SSEPingSecs) * time.Second
 	const pollInterval = time.Duration(2) * time.Second
 	logf(request, "Begin receiving events...")

--- a/routes/gameSubscription.go
+++ b/routes/gameSubscription.go
@@ -61,7 +61,7 @@ func handleSubscription2(response Response, request *Request) {
 	ctx, cancel := context.WithCancel(request.Context())
 	messages := make(chan game.Message)
 	errors := make(chan error, 1)
-	err = game.Subscribe(sess.GameID, messages, errors, ctx)
+	err = game.Subscribe(ctx, sess.GameID, messages, errors)
 	httpInternalErrorIf(response, request, err)
 	logf(request, "Subscription task for %v established", sess.GameID)
 	defer cancel()

--- a/routes/httpContext.go
+++ b/routes/httpContext.go
@@ -41,7 +41,7 @@ func withRedisConn(ctx context.Context, conn redis.Conn) context.Context {
 	return context.WithValue(ctx, requestRedisConnKey, conn)
 }
 
-func redisConn(ctx context.Context) redis.Conn {
+func contextRedisConn(ctx context.Context) redis.Conn {
 	val := ctx.Value(requestRedisConnKey)
 	if val == nil {
 		return nil

--- a/routes/httpContext.go
+++ b/routes/httpContext.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"fmt"
+	"github.com/gomodule/redigo/redis"
 	"log"
 	"math/rand"
 	"sr/config"
@@ -14,7 +15,7 @@ type srContextKey int
 const (
 	requestIDKey        = srContextKey(0)
 	requestConnectedKey = srContextKey(1)
-	requestStartedKey   = srContextKey(2)
+	requestRedisConnKey = srContextKey(3)
 )
 
 func withRequestID(ctx context.Context) context.Context {
@@ -34,6 +35,18 @@ func requestID(ctx context.Context) int {
 		return 0
 	}
 	return val.(int)
+}
+
+func withRedisConn(ctx context.Context, conn redis.Conn) context.Context {
+	return context.WithValue(ctx, requestRedisConnKey, conn)
+}
+
+func redisConn(ctx context.Context) redis.Conn {
+	val := ctx.Value(requestRedisConnKey)
+	if val == nil {
+		return nil
+	}
+	return val.(redis.Conn)
 }
 
 func withConnectedNow(ctx context.Context) context.Context {

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -121,8 +121,8 @@ var certManager = autocert.Manager{
 	Cache:      autocert.DirCache(config.TLSAutocertDir),
 }
 
-func baseTLSConfig() tls.Config {
-	return tls.Config{
+func baseTLSConfig() *tls.Config {
+	return &tls.Config{
 		PreferServerCipherSuites: true,
 		CurvePreferences: []tls.CurveID{
 			tls.CurveP256,
@@ -140,7 +140,7 @@ func baseTLSConfig() tls.Config {
 	}
 }
 
-func autocertTLSConfig() tls.Config {
+func autocertTLSConfig() *tls.Config {
 	conf := baseTLSConfig()
 	conf.GetCertificate = certManager.GetCertificate
 	return conf
@@ -150,7 +150,7 @@ func autocertTLSConfig() tls.Config {
 // Servers
 //
 
-func MakeHTTPRedirectServer() http.Server {
+func MakeHTTPRedirectServer() *http.Server {
 	router := redirectRouter()
 	server := makeServerFromRouter(router)
 	if config.TLSAutocertDir != "" {
@@ -160,7 +160,7 @@ func MakeHTTPRedirectServer() http.Server {
 	return server
 }
 
-func MakeHTTPSiteServer() http.Server {
+func MakeHTTPSiteServer() *http.Server {
 	c := makeCORSConfig()
 	restRouter.NewRoute().HandlerFunc(notFoundHandler)
 	router := c.Handler(restRouter)
@@ -169,8 +169,8 @@ func MakeHTTPSiteServer() http.Server {
 	return server
 }
 
-func MakeHTTPSSiteServer() http.Server {
-	var tlsConf tls.Config
+func MakeHTTPSSiteServer() *http.Server {
+	var tlsConf *tls.Config
 	if config.TLSAutocertDir != "" {
 		tlsConf = autocertTLSConfig()
 	} else {
@@ -181,13 +181,13 @@ func MakeHTTPSSiteServer() http.Server {
 	restRouter.Use(tlsHeadersMiddleware)
 	router := c.Handler(restRouter)
 	server := makeServerFromRouter(router)
-	server.TLSConfig = &tlsConf
+	server.TLSConfig = tlsConf
 	server.Addr = config.PublishHTTPS
 	return server
 }
 
-func makeServerFromRouter(router http.Handler) http.Server {
-	return http.Server{
+func makeServerFromRouter(router http.Handler) *http.Server {
+	return &http.Server{
 		ReadTimeout: time.Duration(config.ReadTimeoutSecs) * time.Second,
 		//WriteTimeout:   time.Duration(config.WriteTimeoutSecs) * time.Second,
 		IdleTimeout:    time.Duration(config.IdleTimeoutSecs) * time.Second,

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -106,7 +106,8 @@ func displayRoute(route *mux.Route, handler *mux.Router, parents []*mux.Route) e
 
 func DisplaySiteRoutes() error {
 	err := restRouter.Walk(displayRoute)
-	fmt.Println(" [default] [*]\n")
+	fmt.Println(" [default] [*]")
+	fmt.Println()
 	return err
 }
 

--- a/routes/httpSession.go
+++ b/routes/httpSession.go
@@ -35,7 +35,7 @@ func requestSession(request *Request) (*session.Session, redis.Conn, error) {
 		logf(request, "Didn't have a session ID")
 		return nil, nil, err
 	}
-	conn := redisUtil.Connect()
+	conn := contextRedisConn(request.Context())
 	session, err := session.GetByID(sessionID, conn)
 	if err != nil {
 		logf(request, "Didn't get %s by id", sessionID)

--- a/routes/httpSession.go
+++ b/routes/httpSession.go
@@ -50,7 +50,7 @@ func requestParamSession(request *Request) (*session.Session, redis.Conn, error)
 	if err != nil {
 		return nil, nil, err
 	}
-	conn := redisUtil.Connect()
+	conn := contextRedisConn(request.Context())
 	session, err := session.GetByID(sessionID, conn)
 	if err != nil {
 		redisUtil.Close(conn)

--- a/routes/meta.go
+++ b/routes/meta.go
@@ -41,7 +41,7 @@ func handleCoffee(response Response, request *Request) {
 
 type healthCheckResponse struct {
 	Games    int `json:"games"`
-	Sessions int `json:"sessions`
+	Sessions int `json:"sessions"`
 }
 
 var _ = restRouter.HandleFunc("/health-check", handleHealthCheck).Methods("GET")

--- a/routes/middleware.go
+++ b/routes/middleware.go
@@ -79,9 +79,6 @@ func recoveryMiddleware(wrapped http.Handler) http.Handler {
 
 func rateLimitedMiddleware(wrapped http.Handler) http.Handler {
 	return http.HandlerFunc(func(response Response, request *Request) {
-		if config.RedisConnectionsDebug {
-			logf(request, "Requesting redis connection")
-		}
 		conn := redisUtil.Connect()
 		defer closeRedis(request, conn)
 

--- a/routes/middleware.go
+++ b/routes/middleware.go
@@ -79,6 +79,9 @@ func recoveryMiddleware(wrapped http.Handler) http.Handler {
 
 func rateLimitedMiddleware(wrapped http.Handler) http.Handler {
 	return http.HandlerFunc(func(response Response, request *Request) {
+		if config.RedisConnectionsDebug {
+			logf(request, "Requesting redis connection")
+		}
 		conn := redisUtil.Connect()
 		defer closeRedis(request, conn)
 

--- a/routes/player.go
+++ b/routes/player.go
@@ -51,6 +51,19 @@ func handleUpdatePlayer(response Response, request *Request) {
 				httpBadRequest(response, request, "hue: expected int 0-360")
 			}
 			diff["hue"] = int(hue)
+		case "onlineMode":
+			var mode player.OnlineMode
+			switch value {
+			case "auto":
+				mode = player.OnlineModeAuto
+			case "alwaysOnline":
+				mode = player.OnlineModeOnline
+			case "alwaysOffline":
+				mode = player.OnlineModeOffline
+			default:
+				httpBadRequest(response, request, "onlineMode: invalid mode received")
+			}
+			diff["onlineMode"] = mode
 		default:
 			httpBadRequest(response, request,
 				fmt.Sprintf("Cannot update field %v", key),

--- a/routes/player.go
+++ b/routes/player.go
@@ -19,7 +19,6 @@ type playerUpdateRequest struct {
 func handleUpdatePlayer(response Response, request *Request) {
 	logRequest(request)
 	sess, conn, err := requestSession(request)
-	defer closeRedis(request, conn)
 	httpUnauthorizedIf(response, request, err)
 
 	var updateRequest playerUpdateRequest

--- a/routes/request.go
+++ b/routes/request.go
@@ -27,6 +27,10 @@ var errExtraBody = errors.New("encountered additional data after end of JSON bod
 
 // closeRedis closes the redis connection and logs any errors found
 func closeRedis(request *Request, conn redis.Conn) {
+	if conn == nil {
+		rawLog(1, request, "nil connection passed to closeRedis")
+		return
+	}
 	err := conn.Close()
 	if err != nil {
 		rawLog(1, request, "Error closing redis connection: %v", err)

--- a/routes/request.go
+++ b/routes/request.go
@@ -90,18 +90,16 @@ func logRequest(request *Request, values ...string) {
 			}
 			extra = fmt.Sprintf(" %v", grabbed)
 		}
-		rawLog(1, request, fmt.Sprintf(
+		rawLog(1, request,
 			"<< %v%v %v %v %v",
 			requestRemoteIP(request),
 			extra,
 			request.Proto,
 			request.Method,
 			request.URL,
-		))
+		)
 	} else {
-		rawLog(1, request, fmt.Sprintf("<< %v %v",
-			request.Method, request.URL,
-		))
+		rawLog(1, request, "<< %v %v", request.Method, request.URL)
 	}
 }
 
@@ -111,7 +109,12 @@ func logf(request *Request, format string, values ...interface{}) {
 
 func rawLog(stack int, request *Request, format string, values ...interface{}) {
 	id := requestID(request.Context())
-	message := fmt.Sprintf(format, values...)
+	var message string
+	if len(values) == 0 {
+		message = format
+	} else {
+		message = fmt.Sprintf(format, values...)
+	}
 	var logText string
 	if config.IsProduction {
 		logText = fmt.Sprintf("%03x %v", id, message)

--- a/routes/request.go
+++ b/routes/request.go
@@ -31,8 +31,7 @@ func closeRedis(request *Request, conn redis.Conn) {
 		rawLog(1, request, "nil connection passed to closeRedis")
 		return
 	}
-	err := conn.Close()
-	if err != nil {
+	if err := conn.Close(); err != nil {
 		rawLog(1, request, "Error closing redis connection: %v", err)
 	}
 }

--- a/routes/request.go
+++ b/routes/request.go
@@ -27,6 +27,9 @@ var errExtraBody = errors.New("encountered additional data after end of JSON bod
 
 // closeRedis closes the redis connection and logs any errors found
 func closeRedis(request *Request, conn redis.Conn) {
+	if config.RedisConnectionsDebug {
+		rawLog(1, request, "Called closeRedis with conn %p", conn)
+	}
 	if conn == nil {
 		rawLog(1, request, "nil connection passed to closeRedis")
 		return

--- a/shutdownHandler/shutdownHandler.go
+++ b/shutdownHandler/shutdownHandler.go
@@ -1,0 +1,95 @@
+package shutdownHandler
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"sr/config"
+	"sync"
+)
+
+type ShutdownReason int
+
+const ShutdownInterrupt ShutdownReason = 0
+
+type Client struct {
+	ID      string
+	Channel chan ShutdownReason
+}
+
+// WaitGroup is `Wait()`ed on in the main() thread.
+var WaitGroup = new(sync.WaitGroup)
+
+var clientChannel = make(chan *Client)
+
+func MakeClient(id string) *Client {
+	client := &Client{
+		ID:      id,
+		Channel: make(chan ShutdownReason),
+	}
+	clientChannel <- client
+	return client
+}
+
+func (c *Client) Close() {
+	clientChannel <- c
+	close(c.Channel)
+}
+
+func handleShutdown() {
+	sigint := make(chan os.Signal, 2)
+	signal.Notify(sigint, os.Interrupt)
+	clients := make(map[*Client]bool)
+	sigintReceived := false
+	// WaitGroup starts at 1 beacuse we're waiting for an interrupt.
+	WaitGroup.Add(1)
+
+	if config.ShutdownHandlersDebug {
+		log.Print("Shutdown handler routine started.")
+	}
+	for {
+		select {
+		case client := <-clientChannel:
+			if _, found := clients[client]; found {
+				if config.ShutdownHandlersDebug {
+					log.Printf("(%v) Removing %v", len(clients)-1, client.ID)
+				}
+				delete(clients, client)
+				WaitGroup.Done()
+			} else {
+				if sigintReceived {
+					if config.ShutdownHandlersDebug {
+						log.Printf("Received %v after sigint", client.ID)
+					}
+					client.Channel <- ShutdownInterrupt
+				}
+				if config.ShutdownHandlersDebug {
+					log.Printf("(%v) Adding %v", len(clients)+1, client.ID)
+				}
+				WaitGroup.Add(1)
+				clients[client] = true
+			}
+		case <-sigint:
+			if sigintReceived {
+				log.Print("Aborting...")
+				os.Exit(1)
+			}
+			if config.ShutdownHandlersDebug && len(clients) == 0 {
+				log.Print("No clients are currently registered")
+			}
+			log.Print("Shutting down... (ctrl+C to force)")
+			WaitGroup.Done() // If there are no clients, this will begin exiting
+			sigintReceived = true
+			for client := range clients {
+				if config.ShutdownHandlersDebug {
+					log.Printf("- Sent shutdown to %v", client.ID)
+				}
+				client.Channel <- ShutdownInterrupt
+			}
+		}
+	}
+}
+
+func Init() {
+	go handleShutdown()
+}

--- a/update/playerUpdate.go
+++ b/update/playerUpdate.go
@@ -15,6 +15,35 @@ type Player interface {
 	MakeRedisCommand() (string, redis.Args)
 }
 
+type PlayerOnline struct {
+	id     id.UID
+	online bool
+}
+
+func (update *PlayerOnline) MakeRedisCommand() (string, redis.Args) {
+	panic("MakeRedisCommand called on update.PlayerOnline")
+}
+
+func (update *PlayerOnline) Type() string {
+	return UpdateTypePlayer
+}
+
+func (update *PlayerOnline) PlayerID() id.UID {
+	return update.id
+}
+
+func (update *PlayerOnline) MarshalJSON() ([]byte, error) {
+	diff := make(map[string]bool, 1)
+	diff["online"] = update.online
+	return json.Marshal([]interface{}{
+		UpdateTypePlayer, update.id, diff,
+	})
+}
+
+func ForPlayerOnline(playerID id.UID, online bool) Player {
+	return &PlayerOnline{id: playerID, online: online}
+}
+
 type playerDiff struct {
 	id   id.UID
 	diff map[string]interface{}

--- a/update/playerUpdate.go
+++ b/update/playerUpdate.go
@@ -13,6 +13,7 @@ type Player interface {
 
 	PlayerID() id.UID
 	MakeRedisCommand() (string, redis.Args)
+	IsEmpty() bool
 }
 
 type PlayerOnline struct {
@@ -30,6 +31,10 @@ func (update *PlayerOnline) Type() string {
 
 func (update *PlayerOnline) PlayerID() id.UID {
 	return update.id
+}
+
+func (update *PlayerOnline) IsEmpty() bool {
+	return false
 }
 
 func (update *PlayerOnline) MarshalJSON() ([]byte, error) {
@@ -61,6 +66,10 @@ func (update *playerDiff) PlayerID() id.UID {
 	return update.id
 }
 
+func (update *playerDiff) IsEmpty() bool {
+	return len(update.diff) == 0
+}
+
 func (update *playerDiff) MarshalJSON() ([]byte, error) {
 	fields := []interface{}{
 		UpdateTypePlayer, update.id, update.diff,
@@ -86,6 +95,10 @@ func (update *playerAdd) Type() string {
 
 func (update *playerAdd) PlayerID() id.UID {
 	return update.player.ID
+}
+
+func (update *playerAdd) IsEmpty() bool {
+	return false
 }
 
 func (update *playerAdd) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Players have a status indicating if they're connected to a game. 
Players may also choose to always display as online or offline.

- Migrate redis `conn` into the Request Context after rate limiting
- Added system for cleanup before SIGINT termination
- Rewrote subscription handler
- Added `DEBUG` flags to increase logging for Redis connection 
open/close, shutdown handlers, and SSE streams

Known issue: memory leak in Redis subscription helper, which causes
the handler and connection to listen after the main handler has exited.
This is caused by a library limitation.