### PR TITLE
Host the website via the server

### DIFF
--- a/compress-all.sh
+++ b/compress-all.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+gzip -rk @1
+
+find @1 -type f -name '*.woff2.gz' -print -exec rm {} \;
+
+gzip -lr @1

--- a/compress-all.sh
+++ b/compress-all.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-gzip -rk @1
+gzip -rk $1
 
-find @1 -type f -name '*.woff2.gz' -print -exec rm {} \;
+find $1 -type f -name '*.woff2.gz' -print -exec rm {} \;
 
-gzip -lr @1
+gzip -lr $1

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -36,32 +37,80 @@ var (
 	// This value is ignored on production.
 	SlowResponsesDebug = readBool("SLOW_RESPONSES_DEBUG", false)
 
-	// Go Server Configuration
+	// Go Servers Configuration
 	//
-	// Shadowroller's API can run on either an HTTP or HTTPS server (both cannot
-	// be set). An HTTP redirect server which redirects requests to HTTPS can be
-	// run. If you are running on production behind a SSL-terminating reverse
-	// proxy, you will need to set ReverseProxied to true. Otherwise, all options
-	// are available in non-production environments.
+	// Shadowroller runs web servers for a few different functions:
+	// - API: an API server that acts as the interface to the backend
+	// - FRONTEND: a frontend server that hosts the code for the frontend (a subpath of API)
+	// - REDIRECT: a redirect server that forwards HTTP requests to HTTPS
+	//
+	// The system used here is designed for some flexibility in a few environments:
+	// development, as a do-it-all standalone server, and as the backend with separate
+	// frontend hosting. However, the three components are not generally standalone servers.
+	// Shadowroller is not written to only run the frontend server or run the frontend server
+	// on a different port than the API server. If you need these features, please file an
+	// issue or open a pull request.
+	//
+	// Local/Development:
+	//
+	// In development, the API server can run with no redirect, and the frontend should
+	// run separately via Node. HTTPS may be used for the API if desired.
+	// The default publish options are designed for this:
+	// - MAIN_LISTEN_HTTP=<port> (3001 default)
+	// - // alternatively, API_PUBLISH_HTTPS=<port>, along with API_HTTPS_* fields.
+	// - REDIRECT_LISTEN_HTTP unset (default)
+	// - HOST_FRONTEND unset (default)
+	// You can disable CORS (auto-respond with *) in a private environment:
+	// - DISABLE_CORS_CHECKS unset (!isProduction default, optional)
+	// - API_ORIGIN=<url> (http://localhost default, something else if desired or using a different port)
+	// - FRONTEND_ORIGIN=<url> (optional, http://localhost:3000 default to match the frontend dev server)
+	//
+	//
+	// Full Stack:
+	//
+	// With this configuration, sr-server hosts the frontend static site code and runs the
+	// backend over HTTPS. This also includes an HTTP redirect server (which isn't super
+	// relevant these days).
+	// Set publishing options:
+	// - API_LISTEN_HTTPS=<port>     (< you should use other ports and forward to 80/443 if possible)
+	// - REDIRECT_LISTEN_HTTP=<port> (< this makes running as non-root user a non-issue)
+	// - HOST_FRONTEND=by-host-header (default unset, publish the frontend/api via a Host header check)
+	// The frontend publishes at the Host/subdomain specified in the CORS options:
+	// - FRONTEND_ORIGIN=<origin> (i.e. https://my.site)
+	// - API_ORIGIN=<origin> (i.e. https://api.my.site)
+	//
+	//
+	// Backend Only:
+	//
+	// In this configuration, you run the frontend through a static provider
+	// (it should work with anything that supports an SPA) and the backend on its
+	// own. You may not need the redirect server if you're behind a reverse proxy.
+	// HTTP API server behind a reverse proxy:
+	// - REVERSE_PROXIED=true (required to set in production)
+	// - MAIN_LISTEN_HTTP=<port>
+	// Or to publish HTTPS:
+	// - MAIN_LISTEN_HTTPS=<port>
+	// Don't publish the redirect or frontend:
+	// - REDIRECT_LISTEN_HTTP unset (default)
+	// - HOST_FRONTEND unset (default)
+	// CORS:
+	// - FRONTEND_ORIGIN=<origin> (still needed for CORS)
+	// - API_ORIGIN=<origin> (still needed for CORS)
 
-	// PublishHTTPS sets a port at which an HTTPS server will run the REST API.
-	// Alternatively, an HTTP server may be used (in development or if proxied).
-	// This is required on production if ReverseProxied is not set.
-	PublishHTTPS = readString("PUBLISH_HTTPS", "")
-	// PublishRedirect sets a port at which a server will run an HTTP->HTTPS
-	// redirect server (giving a 307 response to HTTP requests).
-	PublishRedirect = readString("PUBLISH_REDIRECT", "")
-	// PublishHTTP sets a port at which an HTTP server will run the REST API.
-	// Alternatively, an HTTPS server may be used.
-	// If used on production, ReverseProxied must be set to true.
-	PublishHTTP = readString("PUBLISH_HTTP", ":3001")
-	// ClientIPHeader sets a header to use for client IP addresses instead
-	// of just using the request's RemoteAddr. If the header is not found,
-	// RemoteAddr is used.
-	ClientIPHeader = readString("CLIENT_IP_HEADER", "")
-	// LogExtraHeaders allows for more headers to be logged with each request
-	LogExtraHeaders = readStringArray("LOG_EXTRA_HEADERS", "")
-	// ReverseProxied must be set to true if an HTTP API server is used on
+	// Main server configuration (API and optional frontend)
+
+	// MainListenHTTP is the port which the main server listens for HTTP requests
+	MainListenHTTP = readString("MAIN_LISTEN_HTTP", ":3001")
+	// MainListenHTTPS is the port which the main server listens for HTTPS requests
+	MainListenHTTPS = readString("MAIN_LISTEN_HTTPS", "")
+	// HostFrontend determines if and how the frontend site is hosted
+	HostFrontend = readString("HOST_FRONTEND", "")
+
+	// Redirect server configuration (HTTP -> HTTPS forwarder)
+
+	// RedirectListenHTTP is the port which the redirect server listens for HTTP requests
+	RedirectListenHTTP = readString("FRONTEND_LISTEN_HTTP", "")
+	// ReverseProxied must be set to true if an HTTP-only main server is used on
 	// production. It is ignored otherwise.
 	ReverseProxied = readBool("REVERSE_PROXIED", false)
 
@@ -83,16 +132,26 @@ var (
 	// TLSCertFiles is a list of the file names for the pem, private key cert files.
 	TLSCertFiles = readStringArray("TLS_CERT_FILES", "")
 
-	// Frontend Configuration
-	// These options allow the frontend to be deployed on a separate server or
-	// domain from the server. These values are used locally and in production.
+	// CORS options
+	// These are the origins that we allow cross-origin requests between.
+	// If the frontend is hosted by sr-server, it uses the FrontendOrigin to check
+	// the Host header of requests.
 
-	// FrontendDomain is the origin domain of the frontend, used for CORS requests.
-	FrontendDomain = readString("FRONTEND_DOMAIN", "http://localhost:3000")
-	// FrontendAddress is the redirect address that / should redirect to.
-	// This is a full URL, useful for i.e. Github project sites.
-	// If unset, the root URL will not redirect.
-	FrontendAddress = readString("FRONTEND_ADDRESS", FrontendDomain)
+	// DisableCors disables the CORS checks and sends the host forward. Not compatible
+	// with a production environment.
+	DisableCors = readBool("DISABLE_CORS_CHECKS", !IsProduction)
+	// BackendOrigin is the origin (scheme://host:port) for the backend server
+	BackendOrigin = readOrigin("BACKEND_ORIGIN", "http://localhost:3001")
+	// FrontendOrigin is the origin (scheme://host:port) for the frontend server
+	FrontendOrigin = readOrigin("FRONTEND_ORIGIN", "http://localhost:3000")
+
+	// Frontend server configuration
+	// These options are used when the frontend site is hosted via the main server.
+
+	// FrontendBasePath is the base path for the frontend.
+	FrontendBasePath = readString("FRONTEND_BASE_PATH", "")
+	// FrontendGzipped indicates a .gz copy of each file on the frontend is pregenerated
+	FrontendGzipped = readBool("FRONTEND_GZIPPED", true)
 
 	// Timeouts
 
@@ -126,6 +185,15 @@ var (
 	// PersistSessionTTLDays is the amount of time persistent sessions last.
 	PersistSessionTTLDays = readInt("PERSIST_SESSION_TTL_DAYS", 30)
 
+	// HTTP options
+
+	// ClientIPHeader sets a header to use for client IP addresses instead
+	// of just using the request's RemoteAddr. If the header is not found,
+	// RemoteAddr is used.
+	ClientIPHeader = readString("CLIENT_IP_HEADER", "")
+	// LogExtraHeaders allows for more headers to be logged with each request
+	LogExtraHeaders = readStringArray("LOG_EXTRA_HEADERS", "")
+
 	// Library Options
 
 	// RedisURL is the URI used to dial redis.
@@ -144,7 +212,7 @@ var (
 	// EnableTasks enables the /task route, which includes administrative commands.
 	// It is recommended you run a separate sr-server instance with this enabled to
 	// perform administrative tasks.
-	EnableTasks = readBool("ENABLE_TASKS", false)
+	EnableTasks = readBool("ENABLE_TASKS", !IsProduction)
 	// TasksLocalhostOnly enables the localhost filter on the tasks route.
 	// Don't use this to conceal /task from the internet! Shadowroller cannot guarantee
 	// you won't receive a request pretending to be from localhost.
@@ -211,6 +279,23 @@ func readBool(name string, defaultValue bool) bool {
 	return val
 }
 
+func readOrigin(name string, defaultValue string) *url.URL {
+	envVal, ok := os.LookupEnv("SR_" + name)
+	if !ok {
+		parsed, err := url.Parse(defaultValue)
+		if err != nil {
+			panic(fmt.Sprintf("error parsing default value origin for SR_%v: `%v`", name, defaultValue))
+		}
+		return parsed
+	}
+	log.Print("config: read env origin SR_", name)
+	val, err := url.Parse(envVal)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to parse SR_", name, ": ", envVal))
+	}
+	return val
+}
+
 func readKeyFile(name string, defaultValue string) []byte {
 	envVal, ok := os.LookupEnv("SR_" + name)
 	var contents string
@@ -235,41 +320,43 @@ func readKeyFile(name string, defaultValue string) []byte {
 	return val
 }
 
-// VerifyConfig performs sanity checks and normalizes config settings.
+// VerifyConfig performs sanity checks and prints warnings.
 func VerifyConfig() {
 	if IsProduction {
 		if SlowResponsesDebug {
-			log.Print("Config normalization: set SlowResponsesDebug = false")
-			SlowResponsesDebug = false
+			log.Print("Warning: SlowResponsesDebug = false on production")
 		}
-		if PublishHTTP != "" && !ReverseProxied {
+		if MainListenHTTP != "" && !ReverseProxied {
 			panic("Must set ReverseProxied if using an HTTP server on production")
 		}
 		if TLSHostname == "localhost" {
-			log.Print("Warning: TLSHostname set to localhost on production")
+			log.Print("Warning: TLSHostname = \"localhost\" on production")
 		}
 		if len(HealthCheckSecretKey) != 0 && len(HealthCheckSecretKey) < 256 {
 			panic("HealthcheckSecretKey should be longer")
 		}
-	} else {
-		if !EnableTasks {
-			EnableTasks = true
-		}
 	}
-	if PublishRedirect == PublishHTTPS && PublishHTTPS != "" {
+	if RedirectListenHTTP == MainListenHTTPS && MainListenHTTPS != "" {
 		panic("Cannot publish HTTP redirect and HTTPS servers on the same port!")
 	}
-	if (PublishHTTP == "") == (PublishHTTPS == "") {
-		panic("Must set one of PublishHTTP and PublishHTTPS!")
+	if (MainListenHTTP == "") == (MainListenHTTPS == "") {
+		panic("Must set one of MAIN_LISTEN_HTTP and MAIN_LISTEN_HTTPS!")
 	}
-	if PublishRedirect != "" {
-		if PublishHTTP == PublishRedirect {
+	if RedirectListenHTTP != "" {
+		if MainListenHTTP == RedirectListenHTTP {
 			panic("Cannot publish HTTP server and redirect server on the same port!")
-		} else if PublishHTTP != "" {
-			log.Print("Warning: publishing HTTP server and HTTP redirect server.")
+		} else if MainListenHTTP != "" {
+			log.Print("Warning: publishing HTTP main server and HTTP redirect server.")
 		}
 	}
-	if PublishHTTPS != "" && ((TLSAutocertDir == "") == (len(TLSCertFiles) == 0)) {
+	if MainListenHTTPS != "" && ((TLSAutocertDir == "") == (len(TLSCertFiles) == 0)) {
 		panic("Must set one of TLSAutocertDir and TLSCertFiles!")
+	}
+
+	if HostFrontend != "" && HostFrontend != "by-domain" && HostFrontend != "redirect" {
+		panic("Invalid value for HostFrontend; expected unset, by-domain, or redirect!")
+	}
+	if HostFrontend == "by-domain" && (FrontendOrigin.Host == BackendOrigin.Host) {
+		panic("Must have differing FRONTEND_DOMAIN and BACKEND_DOMAIN hosts for HOST_FRONTEND=by-domain")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,9 +18,6 @@ var (
 
 	// Debugging flags
 
-	// DebugLogConfig toggles the logging of (the rest of) config loading
-	DebugLogConfig = readBool("LOG_CONFIG", true)
-
 	// CORSDebug toggles debugging from the github/rs/cors library.
 	CORSDebug = readBool("CORS_DEBUG", false)
 
@@ -146,7 +143,7 @@ var (
 	// BackendOrigin is the origin (scheme://host:port) for the backend server
 	BackendOrigin = readOrigin("BACKEND_ORIGIN", "http://localhost:3001")
 	// FrontendOrigin is the origin (scheme://host:port) for the frontend server
-	FrontendOrigin = readOrigin("FRONTEND_ORIGIN", "http://localhost:3001")
+	FrontendOrigin = readOrigin("FRONTEND_ORIGIN", "http://localhost:3000")
 
 	// Frontend server configuration
 	// These options are used when the frontend site is hosted via the main server.

--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,7 @@ var (
 	MaxHeaderBytes = readInt("MAX_HEADER_BYTES", 1<<20)
 	// MaxRequestsPer10Secs is a per-address rate limit for all endpoints.
 	// For details, see `middleware.go`.
-	MaxRequestsPer10Secs = readInt("MAX_REQUESTS_PER_10SECS", 16)
+	MaxRequestsPer10Secs = readInt("MAX_REQUESTS_PER_10SECS", 30)
 
 	// TempSessionTTLSecs is the amount of time a temporary session is stored
 	// in redis after the subscription disconnects.

--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,7 @@ var (
 	// MainListenHTTPS is the port which the main server listens for HTTPS requests
 	MainListenHTTPS = readString("MAIN_LISTEN_HTTPS", "")
 	// HostFrontend determines if and how the frontend site is hosted
-	HostFrontend = readString("HOST_FRONTEND", "redirect") // ""
+	HostFrontend = readString("HOST_FRONTEND", "")
 
 	// Redirect server configuration (HTTP -> HTTPS forwarder)
 

--- a/config/config.go
+++ b/config/config.go
@@ -137,9 +137,9 @@ var (
 	// If the frontend is hosted by sr-server, it uses the FrontendOrigin to check
 	// the Host header of requests.
 
-	// DisableCors disables the CORS checks and sends the host forward. Not compatible
+	// DisableCORS disables the CORS checks and sends the host forward. Not compatible
 	// with a production environment.
-	DisableCors = readBool("DISABLE_CORS_CHECKS", !IsProduction)
+	DisableCORS = readBool("DISABLE_CORS_CHECKS", !IsProduction)
 	// BackendOrigin is the origin (scheme://host:port) for the backend server
 	BackendOrigin = readOrigin("BACKEND_ORIGIN", "http://localhost:3001")
 	// FrontendOrigin is the origin (scheme://host:port) for the frontend server

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sr
 
-go 1.14
+go 1.16
 
 require (
 	github.com/gomodule/redigo v1.8.2

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/janberktold/sse v0.0.0-20160725172337-a8efe87fc656
 	github.com/rs/cors v1.7.0
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // ACME support in x/crypto/acme
 )

--- a/main/main.go
+++ b/main/main.go
@@ -88,9 +88,8 @@ func runServer(name string, server *http.Server, tls bool) {
 func main() {
 	log.SetOutput(os.Stdout)
 	if config.IsProduction {
-		log.SetFlags(
-			log.Ldate | log.Ltime | log.LUTC | log.Lmicroseconds,
-		)
+		// You may want to set UTC logs here
+		log.SetFlags(log.Ldate | log.Ltime)
 	} else {
 		log.SetFlags(log.Ltime | log.Lshortfile)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -114,17 +114,17 @@ func main() {
 		panic(fmt.Sprintf("Unable to walk routes: %v", err))
 	}
 
-	if config.PublishRedirect != "" {
+	if config.RedirectListenHTTP != "" {
 		redirectServer := routes.MakeHTTPRedirectServer()
 		go runServer("redirect", redirectServer, false)
 	}
 
-	if config.PublishHTTP != "" {
+	if config.MainListenHTTP != "" {
 		siteServer := routes.MakeHTTPSiteServer()
-		runServer("API", siteServer, false)
+		runServer("main", siteServer, false)
 	} else {
 		siteServer := routes.MakeHTTPSSiteServer()
-		runServer("API", siteServer, true)
+		runServer("main", siteServer, true)
 	}
 	// Wait for all handlers to finish and return cleanly
 	shutdownHandler.WaitGroup.Wait()

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Shadowroller Server
 
+_This repository will be merged with https://github.com/SnirkImmington/shadowroller before the next major update._
+
 ![Shadowroller server logs](https://user-images.githubusercontent.com/1468114/94967935-09da2f00-04ce-11eb-9b36-ce3b842abdda.png)
 
 This repository contains the backend code for running the server behind https://shadowroller.net which supports the "multiplayer" aspect of Shadowroller.
@@ -37,6 +39,8 @@ want to get ahead of myself when there are features to write.
 
 # Run it yourself
 
+_The ability to host the frontend was just introduced, and the repo merge is upcoming. More CI scripts (that run on production) and documentation will be added to the merged repo._
+
 ## Docker
 
 There's a `Dockerfile` and `docker-compose.yml` included to run the project with Docker.
@@ -48,7 +52,7 @@ It uses the `golang` and `redis` packages, as well as [`reflex`](https://github.
 Right now, the server only has two parts: the REST API and Redis database. As long as you have Go and Redis installed, you can run it without other
 dependencies.
 
-`sr-server` is a Go 1.14 module. You can build it with `go build`, or use a tool like [reflex](https://github.com/cespare/reflex) like the Dockerfile does.
+`sr-server` is a Go 1.16 module. You can build it with `go build`, or use a tool like [reflex](https://github.com/cespare/reflex) like the Dockerfile does.
 The API exposes itself at `0.0.0.0:3001` by default (configurable), which allows devices on your LAN to connect.
 If you run the [frontend](https://github.com/SnirkImmington/shadowroller), in dev mode as well, it will find the backend.
 
@@ -70,3 +74,13 @@ Let's Encrypt TLS server inspired by: https://blog.kowalczyk.info/article/Jl3G/h
 Gist of the above: https://github.com/kjk/go-cookbook/blob/master/free-ssl-certificates/main.go
 
 TLS hardening options copied from: https://blog.cloudflare.com/exposing-go-on-the-internet/
+
+Backend routing via the Gorilla mux library https://github.com/gorilla/mux
+
+CORS support via https://github.com/rs/cors
+
+SSE helper https://github.gom/janberktold/sse
+
+Current Redis library https://github.com/gomodule/redigo
+
+Let's Encrypt support (if enabled) via `acme` of https://golang.org/x/crypto

--- a/remove-compressed.sh
+++ b/remove-compressed.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+find @1 -type f -name '*.gz' -print -exec rm {} \;

--- a/remove-compressed.sh
+++ b/remove-compressed.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-find @1 -type f -name '*.gz' -print -exec rm {} \;
+find $1 -type f -name '*.gz' -print -exec rm {} \;

--- a/routes/frontend.go
+++ b/routes/frontend.go
@@ -130,7 +130,8 @@ func openFrontendFile(filePath string, useZipped bool, useDefault bool) (*os.Fil
 // /static/subdir/file.hash.ext
 //
 
-var _ = frontendRouter.PathPrefix("/static").HandlerFunc(handleFrontendStatic)
+// Part of makeFrontendRouter
+//var _ = frontendRouter.PathPrefix("/static").HandlerFunc(handleFrontendStatic)
 
 func handleFrontendStatic(response Response, request *Request) {
 	logFrontendRequest(request)
@@ -177,7 +178,8 @@ func handleFrontendStatic(response Response, request *Request) {
 	logServedContent(response, request, requestFile, zipped)
 }
 
-var _ = frontendRouter.NewRoute().HandlerFunc(handleFrontendBase)
+// Part of makeFrontendRouter
+//var _ = frontendRouter.NewRoute().HandlerFunc(handleFrontendBase)
 
 // /path
 func handleFrontendBase(response Response, request *Request) {

--- a/routes/frontend.go
+++ b/routes/frontend.go
@@ -1,0 +1,209 @@
+package routes
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"sr/config"
+	"strings"
+)
+
+// Serve static files according to webpack's convention.
+
+const hashLength = 8
+
+var validStaticSubdirs = []string{"media", "js", "css"}
+
+func stringArrayContains(array []string, val string) bool {
+	for _, inArray := range array {
+		if inArray == val {
+			return true
+		}
+	}
+	return false
+}
+
+func invalidPath(path string) bool {
+	trimmed := strings.Trim(path, "/")
+	return path == "." || !fs.ValidPath(path)
+}
+
+func etagForFile(subFolder string, fileName string) string {
+	ext := path.Ext(fileName) // the .map files have the same hash as the originals
+	switch subFolder {
+	case "css/":
+		var lastDot int
+		// {main|i}.hash.chunk.css[.map]
+		if strings.HasSuffix(fileName, ".map") {
+			lastDot := len(fileName) - len(".chunk.css.map")
+		} else if strings.HasSuffix(fileName, ".css") {
+			lastDot := len(fileName) - len(".chunk.css")
+		} else {
+			return ""
+		}
+		// expecting len("main.") or len("i.") leftover
+		if len(fileName)-lastDot < 2 {
+			return ""
+		}
+		return fileName[lastDot-hashLength:lastDot] + ext
+	case "media/":
+		lastDot := strings.LastIndex(fileName, ".")
+		// expect at least an original file with a name like f.js
+		if lastDot == -1 || len(fileName) < lastDot-hashLength-3 {
+			return ""
+		}
+		return fileName[lastDot-hashLength : lastDot]
+	case "js/":
+		var offset int
+		if strings.HasPrefix(fileName, "runtime-main.") {
+			offset = len("runtime-main.")
+		} else if strings.HasPrefix(fileName, "main.") {
+			offset = len("main.")
+		} else {
+			offset = strings.Index(fileName, ".")
+		}
+		if offset == -1 || len(fileName) < offset+hashLength+3 {
+			return ""
+		}
+		return fileName[offset : offset+hashLength]
+	default:
+		return ""
+	}
+}
+
+func openFrontendFile(filePath string, useZipped bool, useDefault bool) (*os.File, bool, bool, error) {
+	var file *os.File
+	var err error
+	// Try to open <file>.gz
+	if useZipped {
+		file, err := os.Open(path.Join(config.FrontendBasePath, filePath+".gz"))
+		if err == nil {
+			return file, true, false, nil
+		}
+	}
+	// Either not found, or can't use compressed
+	// Try to open <file>
+	file, err = os.Open(path.Join(config.FrontendBasePath, filePath))
+	if err == nil {
+		return file, false, false, nil
+	}
+	// Stop checking here for /static/invalidfile, otherwise default to /index.html
+	if !useDefault {
+		return nil, false, false, fmt.Errorf("unable to open %v: %v", filePath, err)
+	}
+	if useZipped {
+		// Try to open index.html.gz
+		file, err = os.Open(path.Join(config.FrontendBasePath, "index.html.gz"))
+		if err == nil {
+			return file, false, true, nil
+		}
+		// allow for not found
+		log.Print("Warning: Error opening /index.html.gz with zipping: %v", err)
+	}
+	// ignore not found, could still be a name issue
+	// Try to open index.html
+	file, err = os.Open(path.Join(config.FrontendBasePath, "index.html"))
+	if err == nil {
+		return file, false, true, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, false, true, fmt.Errorf("opening defaulted /index: %w", err)
+	}
+	// index.html not found
+	return nil, false, true, fmt.Errorf("got not found for /index: %w", err)
+}
+
+// /static/path
+func handleFrontendStatic(response Response, request *Request) {
+	logRequest(request)
+	requestPath := request.URL.Path
+	requestDir, requestFile := path.Split(requestPath)
+	fetchGzipped := config.FrontendGzipped && stringArrayContains(request.Header.Values("Content-Type"), "gzip")
+	logf(request, "static path = %v, dir = %v, file = %v", requestPath, requestDir, requestFile)
+
+	if invalidPath(requestPath) || strings.Count(requestPath, "/") != 2 {
+		logf(request, "Path was invalid")
+		httpBadRequest(response, request, requestPath)
+	}
+	subDir := requestDir[len("static/") : len(requestDir)-1]
+	if !stringArrayContains(validStaticSubdirs, subDir) {
+		logf(request, "Invalid subdir %v", subDir)
+		httpNotFound(response, request, requestPath)
+	}
+	logf(request, "Received request for static %v file %v", subDir, requestFile)
+
+	// This data is seriously cacheable
+	response.Header().Set("Cache-Control", "max-age=31536000, public, immutable")
+
+	etag := etagForFile(subDir, requestFile)
+	if etag != "" {
+		logf(request, "Adding etag %v", etag)
+		response.Header().Add("Etag", etag)
+	}
+
+	file, zipped, defaulted, err := openFrontendFile(requestPath, fetchGzipped, false)
+	httpInternalErrorIf(response, request, err)
+	defer file.Close()
+
+	info, err := file.Stat()
+	httpInternalErrorIf(response, request, err)
+
+	if zipped {
+		response.Header().Add("Content-Encoding", "gzip")
+		response.Header().Add("Vary", "Accept-Encoding")
+	}
+
+	if etag == "" {
+		logf(request, "!! Unable to find etag for request to %v", requestPath)
+	}
+
+	// calls checkIfMatch(), which looks at modtime/If-Unmodified-Since and Etag/If-None-Match header.
+	// we've already set the Etag, so if the client's already seen this, we can skip actually reading the file.
+	http.ServeContent(response, request, requestFile, info.ModTime(), file)
+}
+
+// /path
+func handleFrontendBase(response Response, request *Request) {
+	logRequest(request)
+	requestPath := request.URL.Path
+	requestDir, requestFile := path.Split(requestPath)
+	fetchGzipped := config.FrontendGzipped && stringArrayContains(request.Header.Values("Content-Type"), "gzip")
+	logf(request, "path = `%v`, dir = `%v`, file = `%v`", requestPath, requestDir, requestFile)
+
+	logf(request, "Getting a non-static file")
+	resetPath := func() {
+		requestDir = "/"
+		requestFile = "index.html"
+		requestPath = "/index.html"
+	}
+
+	// If it's a subdir that's not /static, we know without checking that file doesn't exist
+	// This should be the case with most SPA paths, i.e. /join/<gameID> but not /about.
+	if strings.Count(requestDir, "/") != 1 {
+		logf(request, "It's a subpath, definitely going to need /index.html")
+		resetPath()
+	}
+
+	// We shouldn't set a max-age cache header, we should rely on if-not-modified (and also just set up PWA stuff).
+	// response.Header.Set("Cache-Control", "max-age=86400")
+
+	file, zipped, defaulted, err := openFrontendFile(requestPath, fetchGzipped, true)
+	httpInternalErrorIf(response, request, err)
+	defer file.Close()
+
+	info, err := file.Stat()
+	httpInternalErrorIf(response, request, err)
+
+	if zipped {
+		response.Header().Add("Content-Encoding", "gzip")
+		response.Header().Add("Vary", "Accept-Encoding")
+	}
+
+	// Serve the content in the file, sending the original MIME type (based on file name)
+	// calls checkIfMatch(), which only checks modtime since we don't add cache information.
+	http.ServeContent(response, request, requestFile, info.ModTime(), file)
+}

--- a/routes/game.go
+++ b/routes/game.go
@@ -395,7 +395,7 @@ func handleReroll(response Response, request *Request) {
 func collectRolls(in interface{}) ([]int, error) {
 	rolls, ok := in.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("Unable to assert %v as []interface{}", in)
+		return nil, fmt.Errorf("unable to assert %v as []interface{}", in)
 	}
 	out := make([]int, len(rolls))
 	for i, val := range rolls {

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -78,8 +78,8 @@ func makeCORSConfig() *cors.Cors {
 	if config.IsProduction {
 		c = cors.New(cors.Options{
 			AllowedOrigins: []string{
-				config.FrontendDomain,
-				"https://" + config.TLSHostname,
+				config.FrontendOrigin.String(),
+				config.BackendOrigin.String(),
 			},
 			AllowedHeaders:   []string{"Authentication", "Content-Type"},
 			AllowCredentials: true,
@@ -169,7 +169,7 @@ func MakeHTTPRedirectServer() *http.Server {
 	if config.TLSAutocertDir != "" {
 		server.Handler = certManager.HTTPHandler(server.Handler)
 	}
-	server.Addr = config.PublishRedirect
+	server.Addr = config.RedirectListenHTTP
 	return server
 }
 
@@ -178,7 +178,7 @@ func MakeHTTPSiteServer() *http.Server {
 	restRouter.NewRoute().HandlerFunc(notFoundHandler)
 	router := c.Handler(restRouter)
 	server := makeServerFromRouter(router)
-	server.Addr = config.PublishHTTP
+	server.Addr = config.MainListenHTTP
 	return server
 }
 
@@ -195,7 +195,7 @@ func MakeHTTPSSiteServer() *http.Server {
 	router := c.Handler(restRouter)
 	server := makeServerFromRouter(router)
 	server.TLSConfig = tlsConf
-	server.Addr = config.PublishHTTPS
+	server.Addr = config.MainListenHTTPS
 	return server
 }
 

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -56,7 +56,6 @@ func makeFrontendRouter() *mux.Router {
 
 func makeTasksRouter() *mux.Router {
 	router := mux.NewRouter()
-	router.NotFoundHandler = http.HandlerFunc(notFoundHandler)
 	return router.PathPrefix("/task").Subrouter()
 }
 
@@ -71,13 +70,12 @@ func makeMainRouter() *mux.Router {
 	base.NotFoundHandler = shouldNotBeCalledHandler
 	switch config.HostFrontend {
 	case "":
-		base.NewRoute().Handler(restRouter)
+		base.NewRoute().Name("Backend").Handler(restRouter)
 		return base
 	case "by-domain":
 		base.Host(config.BackendOrigin.Host).Name(config.BackendOrigin.Host).Handler(restRouter)
 		base.Host(config.FrontendOrigin.Host).Name(config.FrontendOrigin.Host).Handler(frontendRouter)
 		base.NewRoute().Name("[Default Host redirect]").Handler(handleFrontendRedirect) // Called if an invalid host is specified
-		//base.NotFoundHandler = handleFrontendRedirect // Should only be called if an invalid Host is specified by a client
 		return base
 	case "redirect":
 		base.PathPrefix("/api").Handler(restRouter)

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -52,6 +52,12 @@ func makeFrontendRouter() *mux.Router {
 	return router
 }
 
+func makeTasksRouter() *mux.Router {
+	router := mux.NewRouter()
+	router.NotFoundHandler = http.HandlerFunc(notFoundHandler)
+	return router.PathPrefix("/task").Subrouter()
+}
+
 var shouldNotBeCalledHandler = http.HandlerFunc(func(response Response, request *Request) {
 	logRequest(request)
 	logf(request, "Default handler called!")
@@ -101,7 +107,7 @@ func notFoundHandler(response Response, request *Request) {
 }
 
 var handleFrontendRedirect = http.HandlerFunc(func(response Response, request *Request) {
-	logf(request, "frontend redirect")
+	logRequest(request)
 	var status int
 	if config.FrontendRedirectPermanent {
 		status = http.StatusMovedPermanently
@@ -161,7 +167,7 @@ func displayRoute(route *mux.Route, handler *mux.Router, parents []*mux.Route) e
 	return nil
 }
 
-// DisplaySiteRoutes prints the list of routes the restRouter will handle
+// DisplaySiteRoutes prints the list of routes the site will handle
 func DisplaySiteRoutes() error {
 	err := makeMainRouter().Walk(displayRoute)
 	if err != nil {

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -124,7 +124,7 @@ var handleFrontendRedirect = http.HandlerFunc(func(response Response, request *R
 
 func makeCORSConfig() *cors.Cors {
 	var c *cors.Cors
-	if config.IsProduction {
+	if config.IsProduction || !config.DisableCORS {
 		c = cors.New(cors.Options{
 			AllowedOrigins: []string{
 				config.FrontendOrigin.String(),
@@ -138,7 +138,7 @@ func makeCORSConfig() *cors.Cors {
 		c = cors.New(cors.Options{
 			AllowOriginFunc: func(origin string) bool {
 				if config.CORSDebug {
-					log.Print("Accepting CORS origin ", origin)
+					log.Printf("Accepting CORS origin %v", origin)
 				}
 				return true
 			},

--- a/routes/httpServer.go
+++ b/routes/httpServer.go
@@ -19,6 +19,8 @@ import (
 
 var restRouter = apiRouter()
 
+var staticRouter = makeStaticRouter()
+
 // BaseRouter produces a router for the API
 func BaseRouter() *mux.Router {
 	router := mux.NewRouter()
@@ -35,8 +37,18 @@ func BaseRouter() *mux.Router {
 
 func apiRouter() *mux.Router {
 	router := BaseRouter()
+	// router.Host(config.API_HOST)
 	router.Use(mux.MiddlewareFunc(headersMiddleware))
 	router.NotFoundHandler = http.HandlerFunc(notFoundHandler)
+	return router
+}
+
+func makeStaticRouter() *mux.Router {
+	router := BaseRouter()
+	router.Use(
+	//mux.MiddlewareFunc(headersMiddleware),
+	//mux.MiddlewareFunc(compressionMiddleware)
+	)
 	return router
 }
 

--- a/routes/meta.go
+++ b/routes/meta.go
@@ -20,8 +20,6 @@ func handleRoot(response Response, request *Request) {
 		return
 	}
 	response.Header().Set("Content-Type", "text/plain")
-	_, err := response.Write([]byte("Yep, this is the API."))
-	httpInternalErrorIf(response, request, err)
 	httpNotFound(response, request, "Yep, this is the API.")
 }
 

--- a/routes/middleware.go
+++ b/routes/middleware.go
@@ -18,10 +18,16 @@ func tlsHeadersMiddleware(wrapped http.Handler) http.Handler {
 	})
 }
 
-func headersMiddleware(wrapped http.Handler) http.Handler {
+func universalHeadersMiddleware(wrapped http.Handler) http.Handler {
+	return http.HandlerFunc(func(response Response, request *Request) {
+		response.Header().Set("X-Content-Type-Options", "nosniff")
+		wrapped.ServeHTTP(response, request)
+	})
+}
+
+func restHeadersMiddleware(wrapped http.Handler) http.Handler {
 	return http.HandlerFunc(func(response Response, request *Request) {
 		response.Header().Set("Cache-Control", "no-store")
-		response.Header().Set("X-Content-Type-Options", "nosniff")
 		wrapped.ServeHTTP(response, request)
 	})
 }
@@ -37,7 +43,6 @@ func requestContextMiddleware(wrapped http.Handler) http.Handler {
 
 func localhostOnlyMiddleware(wrapped http.Handler) http.Handler {
 	return http.HandlerFunc(func(response Response, request *Request) {
-		// Not sure if this should just be remote addr.
 		remoteAddr := requestRemoteIP(request)
 		allowed := remoteAddr == "localhost" || remoteAddr == "127.0.0.1" || remoteAddr == "[::1]"
 		message := "disallowed"

--- a/routes/request.go
+++ b/routes/request.go
@@ -25,12 +25,6 @@ type Response = http.ResponseWriter
 
 var errExtraBody = errors.New("encountered additional data after end of JSON body")
 
-func logIfError(request *Request, err error, format string) {
-	if err != nil {
-		rawLog(1, request, format+": %v", err)
-	}
-}
-
 // closeRedis closes the redis connection and logs any errors found
 func closeRedis(request *Request, conn redis.Conn) {
 	if config.RedisConnectionsDebug {

--- a/routes/request.go
+++ b/routes/request.go
@@ -125,7 +125,7 @@ func logFrontendRequest(request *Request) {
 			extra = fmt.Sprintf(" %v", grabbed)
 		}
 		rawLog(1, request,
-			"++ %v%v %v %v %v",
+			"<* %v%v %v %v %v",
 			requestRemoteIP(request),
 			extra,
 			request.Proto,
@@ -133,7 +133,7 @@ func logFrontendRequest(request *Request) {
 			request.URL,
 		)
 	} else {
-		rawLog(1, request, "(( %v %v", request.Method, request.URL)
+		rawLog(1, request, "<* %v %v", request.Method, request.URL)
 	}
 }
 
@@ -175,5 +175,5 @@ func logServedContent(response Response, request *Request, fileName string, zipp
 	if !zipped {
 		msg = "unzipped"
 	}
-	rawLog(1, request, fmt.Sprintf(")) Served %v %v (%v)", fileName, msg, dur))
+	rawLog(1, request, fmt.Sprintf("*> Served %v %v (%v)", fileName, msg, dur))
 }

--- a/routes/request.go
+++ b/routes/request.go
@@ -25,6 +25,12 @@ type Response = http.ResponseWriter
 
 var errExtraBody = errors.New("encountered additional data after end of JSON body")
 
+func logIfError(request *Request, err error, format string) {
+	if err != nil {
+		rawLog(1, request, format+": %v", err)
+	}
+}
+
 // closeRedis closes the redis connection and logs any errors found
 func closeRedis(request *Request, conn redis.Conn) {
 	if config.RedisConnectionsDebug {
@@ -81,7 +87,7 @@ func writeBodyJSON(response Response, value interface{}) error {
 	return json.NewEncoder(response).Encode(value)
 }
 
-func logRequest(request *Request, values ...string) {
+func logRequest(request *Request) {
 	if config.IsProduction {
 		extra := ""
 		if len(config.LogExtraHeaders) != 0 {
@@ -106,6 +112,34 @@ func logRequest(request *Request, values ...string) {
 		)
 	} else {
 		rawLog(1, request, "<< %v %v", request.Method, request.URL)
+	}
+}
+
+func logFrontendRequest(request *Request) {
+	if config.IsProduction {
+		extra := ""
+		if len(config.LogExtraHeaders) != 0 {
+			grabbed := make([]string, len(config.LogExtraHeaders))
+			for i, header := range config.LogExtraHeaders {
+				found := request.Header.Get(header)
+				if found != "" {
+					grabbed[i] = found
+				} else {
+					grabbed[i] = "??"
+				}
+			}
+			extra = fmt.Sprintf(" %v", grabbed)
+		}
+		rawLog(1, request,
+			"++ %v%v %v %v %v",
+			requestRemoteIP(request),
+			extra,
+			request.Proto,
+			request.Method,
+			request.URL,
+		)
+	} else {
+		rawLog(1, request, "(( %v %v", request.Method, request.URL)
 	}
 }
 
@@ -139,4 +173,13 @@ func httpSuccess(response Response, request *Request, message ...interface{}) {
 	}
 	dur := displayRequestDuration(request.Context())
 	rawLog(1, request, fmt.Sprintf(">> 200 %v (%v)", fmt.Sprint(message...), dur))
+}
+
+func logServedContent(response Response, request *Request, fileName string, zipped bool) {
+	dur := displayRequestDuration(request.Context())
+	msg := "zipped"
+	if !zipped {
+		msg = "unzipped"
+	}
+	rawLog(1, request, fmt.Sprintf(")) Served %v %v (%v)", fileName, msg, dur))
 }

--- a/routes/static.go
+++ b/routes/static.go
@@ -1,3 +1,0 @@
-import ()
-
-var static = router.Host("").Subrouter()

--- a/routes/static.go
+++ b/routes/static.go
@@ -1,0 +1,3 @@
+import ()
+
+var static = router.Host("").Subrouter()

--- a/routes/task.go
+++ b/routes/task.go
@@ -26,7 +26,7 @@ func RegisterTasksViaConfig() {
 	}
 }
 
-var tasksRouter = apiRouter().PathPrefix("/task").Subrouter()
+var tasksRouter = makeAPIRouter().PathPrefix("/task").Subrouter()
 
 var _ = tasksRouter.HandleFunc("/clear-all-sessions", handleClearSessions).Methods("GET")
 

--- a/routes/task.go
+++ b/routes/task.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/gomodule/redigo/redis"
-	"net/http"
 	"sr/config"
 	"sr/game"
 	"sr/id"
@@ -18,7 +17,6 @@ import (
 // It must be called after config values are loaded.
 func RegisterTasksViaConfig() {
 	if config.EnableTasks {
-		tasksRouter.NotFoundHandler = http.HandlerFunc(notFoundHandler)
 		restRouter.PathPrefix("/task").Handler(tasksRouter)
 	}
 	if config.TasksLocalhostOnly {
@@ -26,7 +24,7 @@ func RegisterTasksViaConfig() {
 	}
 }
 
-var tasksRouter = makeAPIRouter().PathPrefix("/task").Subrouter()
+var tasksRouter = makeTasksRouter()
 
 var _ = tasksRouter.HandleFunc("/clear-all-sessions", handleClearSessions).Methods("GET")
 

--- a/task/fixPresite.go
+++ b/task/fixPresite.go
@@ -13,7 +13,7 @@ import (
 const closingContent = `</body></html>`
 
 // Yep, using a regex to find an HTML tag
-var matchScriptSrc = regexp.MustCompile(`<script src="(./static/js/[^j]*js)">`)
+var matchScriptSrc = regexp.MustCompile(`<script src="(/static/js/[^j]*js)">`)
 
 func handleRewritePresiteIndexTask(buildIndexPath string, presiteIndexPath string) error {
 	baseFile, err := os.Open(buildIndexPath)
@@ -28,6 +28,9 @@ func handleRewritePresiteIndexTask(buildIndexPath string, presiteIndexPath strin
 	log.Printf("Read build file %s", buildIndexPath)
 
 	matches := matchScriptSrc.FindAll(baseFileBytes, -1)
+	if len(matches) < 3 {
+		return fmt.Errorf("Expected to get at least 3 script tags, got %v", matches)
+	}
 	var result strings.Builder
 	for _, match := range matches {
 		log.Printf("Found `%s`", match)
@@ -49,10 +52,12 @@ func handleRewritePresiteIndexTask(buildIndexPath string, presiteIndexPath strin
 	if _, err = presiteFile.Seek(offset, 0); err != nil {
 		return fmt.Errorf("could not seek to offset %v (of %v) in %s: %w", offset, info.Size(), presiteIndexPath, err)
 	}
+	log.Printf("Seeked to end of file")
 
 	if _, err = presiteFile.WriteString(result.String()); err != nil {
 		return fmt.Errorf("could not write to presite file %s: %w", presiteIndexPath, err)
 	}
+	log.Printf("Wrote all the tags in")
 	if _, err = presiteFile.WriteString(closingContent); err != nil {
 		return fmt.Errorf("could not write closing to presite file %s: %w", presiteIndexPath, err)
 	}

--- a/task/fixPresite.go
+++ b/task/fixPresite.go
@@ -1,0 +1,60 @@
+package task
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Closing content of the prerendered file. presite doesn't include a trailing newline!
+const closingContent = `</body></html>`
+
+// Yep, using a regex to find an HTML tag
+var matchScriptSrc = regexp.MustCompile(`<script src="(./static/js/[^j]*js)">`)
+
+func handleRewritePresiteIndexTask(buildIndexPath string, presiteIndexPath string) error {
+	baseFile, err := os.Open(buildIndexPath)
+	if err != nil {
+		return fmt.Errorf("could not open base file %s: %w", buildIndexPath, err)
+	}
+	defer baseFile.Close()
+	baseFileBytes, err := io.ReadAll(baseFile)
+	if err != nil {
+		return fmt.Errorf("could not read all from base file %s: %w", buildIndexPath, err)
+	}
+	log.Printf("Read build file %s", buildIndexPath)
+
+	matches := matchScriptSrc.FindAll(baseFileBytes, -1)
+	var result strings.Builder
+	for _, match := range matches {
+		log.Printf("Found `%s`", match)
+		result.Write(match)             // whole <script> tag
+		result.WriteString("</script>") // and closing tag
+	}
+
+	presiteFile, err := os.OpenFile(presiteIndexPath, os.O_RDWR, 0o755)
+	if err != nil {
+		return fmt.Errorf("could not open presite file %s: %w", presiteIndexPath, err)
+	}
+	defer presiteFile.Close()
+	log.Printf("Opened presite file %s", presiteIndexPath)
+	info, err := presiteFile.Stat()
+	if err != nil {
+		return fmt.Errorf("could not stat prestie file %s: %w", presiteIndexPath, err)
+	}
+	offset := info.Size() - int64(len(closingContent))
+	if _, err = presiteFile.Seek(offset, 0); err != nil {
+		return fmt.Errorf("could not seek to offset %v (of %v) in %s: %w", offset, info.Size(), presiteIndexPath, err)
+	}
+
+	if _, err = presiteFile.WriteString(result.String()); err != nil {
+		return fmt.Errorf("could not write to presite file %s: %w", presiteIndexPath, err)
+	}
+	if _, err = presiteFile.WriteString(closingContent); err != nil {
+		return fmt.Errorf("could not write closing to presite file %s: %w", presiteIndexPath, err)
+	}
+	return nil
+}

--- a/task/task.go
+++ b/task/task.go
@@ -19,7 +19,7 @@ func RunSelectedTask(task string, args []string) {
 	switch task {
 	case "migrate":
 		if len(args) != 1 {
-			log.Printf("Usage: migrate <gameID>")
+			log.Print("Usage: migrate <gameID>")
 			os.Exit(1)
 		}
 		gameID := args[0]
@@ -33,8 +33,18 @@ func RunSelectedTask(task string, args []string) {
 			log.Printf("Error with task: %v", err)
 			os.Exit(1)
 		}
-
-		log.Printf("Task finished successfully.")
-		os.Exit(0)
+		break
+	case "ppr": // post prerender
+		if len(args) != 2 {
+			log.Print("Usage: ppr <src> <dest>")
+			os.Exit(1)
+		}
+		if err := handleRewritePresiteIndexTask(args[0], args[1]); err != nil {
+			log.Printf("Error with task: %v", err)
+			os.Exit(1)
+		}
+		break
 	}
+	log.Printf("Task finished successfully.")
+	os.Exit(0)
 }


### PR DESCRIPTION
Added an optional server for hosting the frontend. The REST API can be hosted at either a separate domain (as is done in production) or as a subdomain (like /api). There is a build script to pre-zip all the frontend files, which can be served zipped to clients which accept gzip.

There are four values for `SR_HOST_FRONTEND`:
+ "" (empty):  do not host the frontend. Do not redirect to FrontendOrigin at the root.
+ "redirect":  Redirect to FrontendOrigin from the root.
+ "subroute":  Host the frontend at / and /static. Host the REST API at /api.
+ "by-domain": Filter requests by the Host header, FrontendOrigin to frontend and BackendOrigin to backend. Redirect requests with other Host to FrontendOrigin.

- Add frontend server with compression support via precompressed files and ETag via hashed filenames
- Configuration options to separate hosts via domain or subpath
- Scripts to perform gzip compression and removal of compressed files
- Task to fix issues with presite on the frontend
- - Bump required go version to 1.16 to use fs library